### PR TITLE
Fix POD - add description to NAME

### DIFF
--- a/lib/String/Binary/Interpolation.pm
+++ b/lib/String/Binary/Interpolation.pm
@@ -19,11 +19,7 @@ sub import {
 
 =head1 NAME
 
-String::Binary::Interpolation
-
-=head1 DESCRIPTION
-
-Make it easier to interpolate binary bytes into a string
+String::Binary::Interpolation - make it easier to interpolate binary bytes into a string
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to
String-Binary-Interpolation.
We thought you might be interested in it too.

    Description: Fix POD - add description to NAME
     in order to get whatis entry in manpage
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2023-10-28
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libstring-binary-interpolation-perl/raw/master/debian/patches/whatis.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
